### PR TITLE
move resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .settings/
 .vscode/
 log/
+/evm/src/main/resources
 /evm/target/
 /libevm/bin
 /libevm/test/compiled

--- a/evm/pom.xml
+++ b/evm/pom.xml
@@ -7,6 +7,8 @@
   <artifactId>evm</artifactId>
   <version>0.1.0-SNAPSHOT</version>
   <inceptionYear>2022</inceptionYear>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description>This library provides access to a standalone version of the go-ethereum EVM and its state storage layer StateDB and underlying LevelDB.</description>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>

--- a/evm/src/main/java/io/horizen/evm/LibEvm.java
+++ b/evm/src/main/java/io/horizen/evm/LibEvm.java
@@ -3,6 +3,7 @@ package io.horizen.evm;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.sun.jna.Callback;
 import com.sun.jna.Native;
+import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -28,22 +29,10 @@ final class LibEvm {
     // because without it the only reference might be from native code (libevm) and the GC does not know about that
     private static final CallbackProxy proxy = new CallbackProxy();
 
-    private static String getOSLibExtension() {
-        var os = System.getProperty("os.name").toLowerCase();
-        if (os.contains("mac os")) {
-            return "dylib";
-        } else if (os.contains("windows")) {
-            return "dll";
-        }
-        // default to linux file extension
-        return "so";
-    }
-
     static {
-        var libName = "libevm." + getOSLibExtension();
-        logger.info("loading library: {}", libName);
+        logger.info("loading libevm for platform {}", Platform.RESOURCE_PREFIX);
         // bind native methods in this class to libevm
-        Native.register(libName);
+        Native.register("evm");
         // register callback
         SetCallbackProxy(proxy);
         // propagate log4j log level to glog

--- a/libevm/README.md
+++ b/libevm/README.md
@@ -18,7 +18,7 @@ To build Linux and Windows binaries manually see the following sections.
 - `go` version 1.18 or newer
 - `gcc` GNU compiler
 - `gcc-mingw-w64-x86-64` for cross-compilation to Windows
-- `solc` Solidity compiler version 0.8.0 or newer
+- `solc` Solidity compiler version 0.8.18 or newer
   - only required to run tests
 
 ### Linux

--- a/libevm/build.sh
+++ b/libevm/build.sh
@@ -2,11 +2,15 @@
 
 set -ex
 
+resourcesDir=../evm/src/main/resources
+linuxPrefix=linux-x86-64
+windowsPrefix=win32-x86-64
+
 # delete output directory
 rm -rf bin
 
 echo "# building for linux"
-go build -buildmode c-shared -o "bin/linux-x86-64/libevm.so"
+go build -buildmode c-shared -o "bin/$linuxPrefix/libevm.so"
 
 echo "# building for windows"
 GOOS=windows \
@@ -14,17 +18,19 @@ GOARCH=amd64 \
 CGO_ENABLED=1 \
 CC=x86_64-w64-mingw32-gcc \
 CXX=x86_64-w64-mingw32-g++ \
-go build -buildmode c-shared -o bin/win32-x86-64/libevm.dll
+go build -buildmode c-shared -o bin/$windowsPrefix/libevm.dll
 
 # alternative: build using docker container
-#docker build -t horizen/libevm:win32-x86-64 .
-#docker run --rm -v "$PWD":/libevm -w /libevm horizen/libevm:win32-x86-64 /bin/sh -c \
-#  "go build -buildmode c-shared -o bin/win32-x86-64/libevm.dll"
+#docker build -t horizen/libevm:$windowsPrefix .
+#docker run --rm -v "$PWD":/libevm -w /libevm horizen/libevm:$windowsPrefix /bin/sh -c \
+#  "go build -buildmode c-shared -o bin/$windowsPrefix/libevm.dll"
 
 # dump symbols of shared object
-#nm -g bin/linux-x86-64/libevm.so
-#winedump -j export bin/win32-x86-64/libevm.dll
+#nm -g bin/$linuxPrefix/libevm.so
+#winedump -j export bin/$windowsPrefix/libevm.dll
 
 echo "# copy binaries to the EVM package"
-cp -r bin/linux-x86-64 ../evm/target/classes/
-cp -r bin/win32-x86-64 ../evm/target/classes/
+mkdir -p $resourcesDir/$linuxPrefix
+cp bin/$linuxPrefix/libevm.so $resourcesDir/$linuxPrefix/libevm.so
+mkdir -p $resourcesDir/$windowsPrefix
+cp bin/$windowsPrefix/libevm.dll $resourcesDir/$windowsPrefix/libevm.dll


### PR DESCRIPTION
- add description to pom file
- copy libevm binaries to the `resources` directory instead of `target`
  - this way they won't be missing after a `mvn clean`