### PR TITLE
fix tests with newer version of solc

### DIFF
--- a/native/test/contracts.go
+++ b/native/test/contracts.go
@@ -12,7 +12,7 @@ import (
 // note: other interesting parameters for the solidity compiler include:
 // --opcodes to get the compiled code in a "readable" opcode format
 // --storage-layout to get the storage layout of the contract
-//go:generate solc --bin --bin-runtime --hashes --optimize -o compiled --overwrite Storage.sol OpCodes.sol DelegateCaller.sol DelegateReceiver.sol
+//go:generate solc --bin --bin-runtime --hashes --optimize --evm-version paris -o compiled --overwrite Storage.sol OpCodes.sol DelegateCaller.sol DelegateReceiver.sol
 //go:embed compiled
 var compiled embed.FS
 


### PR DESCRIPTION
newer version of solc also expect newer versions of the EVM if not specified otherwise. in this case solc would emit a new op-code that our version of the EVM does not support (yet): PUSH0