### PR TITLE
Added Solidity contracts for staticcall testing.

### DIFF
--- a/native/test/BaseNativeInterface.sol
+++ b/native/test/BaseNativeInterface.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+
+// contract address: 0x00000000000000000000000000000000deadbeef
+interface BaseNativeInterface {
+
+    function retrieve() external view returns (uint32);
+
+    function inc() external view returns (uint32);
+}

--- a/native/test/NativeCaller.sol
+++ b/native/test/NativeCaller.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.7.0 <0.9.0;
+
+import "./BaseNativeInterface.sol";
+
+contract NativeCaller {
+
+    BaseNativeInterface nativeContract = BaseNativeInterface(0x00000000000000000000000000000000DeaDBeef);
+
+    //This function tests that calling a readonly method on a Native Smart Contract using staticcall works
+    // and that calling then a readwrite method works again, so the statedb is readwrite again.
+    function testStaticCallOnReadonlyMethod() public returns (uint32) {
+	address contractAddr = address(nativeContract);
+	(bool success, bytes memory result) = contractAddr.staticcall{gas:10000}(
+            abi.encodeWithSignature("retrieve()")
+        );
+	(uint32 a) = abi.decode(result, (uint32));
+	//Check that statedb is readwrite again
+	(bool success2, bytes memory result2) = contractAddr.call{gas:25000}(
+            abi.encodeWithSignature("inc()")
+        );
+	require(success2, "call should work");
+	return a;
+    }
+
+    //This function tests that calling a readwrite method on a Native Smart Contract using staticcall fails.
+    //It tests also that calling the same method without staticcall works. 	
+    function testStaticCallOnReadwriteMethod() public returns (uint32) {
+	address contractAddr = address(nativeContract);
+	//This should fail
+	(bool success, bytes memory result) = contractAddr.staticcall{gas:25000}(
+            abi.encodeWithSignature("inc()")
+        );
+	require(!success, "Staticcall should fail");
+	//This should work instead.
+	(bool success2, bytes memory result2) = contractAddr.call{gas:25000}(
+            abi.encodeWithSignature("inc()")
+        );
+	require(success2, "call should work");
+	return abi.decode(result2, (uint32));
+    }
+
+    //This function calls a readwrite method on a Native Smart Contract using a contract call.
+    // It should fail because the Solidity interface describing the Native Smart Contract defines the method as view,
+    // even if it actually is readwrite. Using the contract interface, the tx should be automatucally reverted.
+    function testStaticCallOnReadwriteMethodContractCall() public returns (uint32) {
+	return nativeContract.inc{gas: 25000}();
+    }
+
+    //This function is used to test staticcall with nested calls (native => evm => native).
+    function testNestedCalls() public returns (uint32) {
+	address contractAddr = address(nativeContract);
+	(bool success, bytes memory result) = contractAddr.call{gas:25000}(
+            abi.encodeWithSignature("inc()")
+        );
+	require(success, "call should work");
+	return abi.decode(result, (uint32));
+    }
+
+}

--- a/native/test/NativeCaller.sol
+++ b/native/test/NativeCaller.sol
@@ -15,51 +15,51 @@ contract NativeCaller {
     //This function tests that calling a readonly method on a Native Smart Contract using staticcall works
     // and that calling then a readwrite method works again, so the statedb is readwrite again.
     function testStaticCallOnReadonlyMethod() public returns (uint32) {
-	address contractAddr = address(nativeContract);
-	(bool success, bytes memory result) = contractAddr.staticcall{gas:STATIC_CALL_GAS_LIMIT}(
+        address contractAddr = address(nativeContract);
+        (bool success, bytes memory result) = contractAddr.staticcall{gas:STATIC_CALL_GAS_LIMIT}(
             abi.encodeWithSignature("retrieve()")
         );
-	(uint32 a) = abi.decode(result, (uint32));
-	//Check that statedb is readwrite again
-	(bool success2, bytes memory result2) = contractAddr.call{gas:CALL_GAS_LIMIT}(
+        (uint32 a) = abi.decode(result, (uint32));
+        //Check that statedb is readwrite again
+        (bool success2, bytes memory result2) = contractAddr.call{gas:CALL_GAS_LIMIT}(
             abi.encodeWithSignature("inc()")
         );
-	require(success2, "call should work");
-	return a;
+        require(success2, "call should work");
+        return a;
     }
 
     //This function tests that calling a readwrite method on a Native Smart Contract using staticcall fails.
-    //It tests also that calling the same method without staticcall works. 	
+    //It tests also that calling the same method without staticcall works.         
     function testStaticCallOnReadwriteMethod() public returns (uint32) {
-	address contractAddr = address(nativeContract);
-	//This should fail
-	(bool success, bytes memory result) = contractAddr.staticcall{gas:CALL_GAS_LIMIT}(
+        address contractAddr = address(nativeContract);
+        //This should fail
+        (bool success, bytes memory result) = contractAddr.staticcall{gas:CALL_GAS_LIMIT}(
             abi.encodeWithSignature("inc()")
         );
-	require(!success, "Staticcall should fail");
-	//This should work instead.
-	(bool success2, bytes memory result2) = contractAddr.call{gas:CALL_GAS_LIMIT}(
+        require(!success, "Staticcall should fail");
+        //This should work instead.
+        (bool success2, bytes memory result2) = contractAddr.call{gas:CALL_GAS_LIMIT}(
             abi.encodeWithSignature("inc()")
         );
-	require(success2, "call should work");
-	return abi.decode(result2, (uint32));
+        require(success2, "call should work");
+        return abi.decode(result2, (uint32));
     }
 
     //This function calls a readwrite method on a Native Smart Contract using a contract call.
     // It should fail because the Solidity interface describing the Native Smart Contract defines the method as view,
     // even if it actually is readwrite. Using the contract interface, the tx should be automatically reverted.
     function testStaticCallOnReadwriteMethodContractCall() public returns (uint32) {
-	return nativeContract.inc{gas: CALL_GAS_LIMIT}();
+        return nativeContract.inc{gas: CALL_GAS_LIMIT}();
     }
 
     //This function is used to test staticcall with nested calls (native => evm => native).
     function testNestedCalls() public returns (uint32) {
-	address contractAddr = address(nativeContract);
-	(bool success, bytes memory result) = contractAddr.call{gas:CALL_GAS_LIMIT}(
+        address contractAddr = address(nativeContract);
+        (bool success, bytes memory result) = contractAddr.call{gas:CALL_GAS_LIMIT}(
             abi.encodeWithSignature("inc()")
         );
-	require(success, "call should work");
-	return abi.decode(result, (uint32));
+        require(success, "call should work");
+        return abi.decode(result, (uint32));
     }
 
 }

--- a/native/test/NativeCaller.sol
+++ b/native/test/NativeCaller.sol
@@ -8,16 +8,20 @@ contract NativeCaller {
 
     BaseNativeInterface nativeContract = BaseNativeInterface(0x00000000000000000000000000000000DeaDBeef);
 
+    uint256 private constant STATIC_CALL_GAS_LIMIT = 10000;
+    uint256 private constant CALL_GAS_LIMIT = 25000;
+
+
     //This function tests that calling a readonly method on a Native Smart Contract using staticcall works
     // and that calling then a readwrite method works again, so the statedb is readwrite again.
     function testStaticCallOnReadonlyMethod() public returns (uint32) {
 	address contractAddr = address(nativeContract);
-	(bool success, bytes memory result) = contractAddr.staticcall{gas:10000}(
+	(bool success, bytes memory result) = contractAddr.staticcall{gas:STATIC_CALL_GAS_LIMIT}(
             abi.encodeWithSignature("retrieve()")
         );
 	(uint32 a) = abi.decode(result, (uint32));
 	//Check that statedb is readwrite again
-	(bool success2, bytes memory result2) = contractAddr.call{gas:25000}(
+	(bool success2, bytes memory result2) = contractAddr.call{gas:CALL_GAS_LIMIT}(
             abi.encodeWithSignature("inc()")
         );
 	require(success2, "call should work");
@@ -29,12 +33,12 @@ contract NativeCaller {
     function testStaticCallOnReadwriteMethod() public returns (uint32) {
 	address contractAddr = address(nativeContract);
 	//This should fail
-	(bool success, bytes memory result) = contractAddr.staticcall{gas:25000}(
+	(bool success, bytes memory result) = contractAddr.staticcall{gas:CALL_GAS_LIMIT}(
             abi.encodeWithSignature("inc()")
         );
 	require(!success, "Staticcall should fail");
 	//This should work instead.
-	(bool success2, bytes memory result2) = contractAddr.call{gas:25000}(
+	(bool success2, bytes memory result2) = contractAddr.call{gas:CALL_GAS_LIMIT}(
             abi.encodeWithSignature("inc()")
         );
 	require(success2, "call should work");
@@ -43,15 +47,15 @@ contract NativeCaller {
 
     //This function calls a readwrite method on a Native Smart Contract using a contract call.
     // It should fail because the Solidity interface describing the Native Smart Contract defines the method as view,
-    // even if it actually is readwrite. Using the contract interface, the tx should be automatucally reverted.
+    // even if it actually is readwrite. Using the contract interface, the tx should be automatically reverted.
     function testStaticCallOnReadwriteMethodContractCall() public returns (uint32) {
-	return nativeContract.inc{gas: 25000}();
+	return nativeContract.inc{gas: CALL_GAS_LIMIT}();
     }
 
     //This function is used to test staticcall with nested calls (native => evm => native).
     function testNestedCalls() public returns (uint32) {
 	address contractAddr = address(nativeContract);
-	(bool success, bytes memory result) = contractAddr.call{gas:25000}(
+	(bool success, bytes memory result) = contractAddr.call{gas:CALL_GAS_LIMIT}(
             abi.encodeWithSignature("inc()")
         );
 	require(success, "call should work");

--- a/native/test/contracts.go
+++ b/native/test/contracts.go
@@ -12,18 +12,18 @@ import (
 // note: other interesting parameters for the solidity compiler include:
 // --opcodes to get the compiled code in a "readable" opcode format
 // --storage-layout to get the storage layout of the contract
-//go:generate solc --bin --bin-runtime --hashes --optimize --evm-version paris -o compiled --overwrite Storage.sol OpCodes.sol DelegateCaller.sol DelegateReceiver.sol NativeInterop.sol
+//go:generate solc --bin --bin-runtime --hashes --optimize --evm-version paris -o compiled --overwrite Storage.sol OpCodes.sol DelegateCaller.sol DelegateReceiver.sol NativeInterop.sol BaseNativeInterface.sol NativeCaller.sol
 //go:embed compiled
 var compiled embed.FS
 
 // load contracts from embedded compiled data
 var (
-	Storage          = StorageContract{newContract("compiled/Storage")}
-	OpCodes          = OpCodesContract{newContract("compiled/OpCodes")}
-	DelegateCaller   = DelegateCallerContract{newContract("compiled/DelegateCaller")}
-	DelegateReceiver = DelegateReceiverContract{newContract("compiled/DelegateReceiver")}
-	NativeInterop    = NativeInteropContract{newContract("compiled/NativeInterop")}
-	ForgerStakes     = ForgerStakesContract{newContract("compiled/ForgerStakes")}
+	Storage                = StorageContract{newContract("compiled/Storage")}
+	OpCodes                = OpCodesContract{newContract("compiled/OpCodes")}
+	DelegateCaller         = DelegateCallerContract{newContract("compiled/DelegateCaller")}
+	DelegateReceiver       = DelegateReceiverContract{newContract("compiled/DelegateReceiver")}
+	NativeInterop          = NativeInteropContract{newContract("compiled/NativeInterop")}
+	ForgerStakes           = ForgerStakesContract{newContract("compiled/ForgerStakes")}
 )
 
 type contract struct {


### PR DESCRIPTION
Added some Solidity smart contracts that are used for testing staticcall calls between native and solidity smart contracts.

- See [SDK-1351](https://horizenlabs.atlassian.net/browse/SDK-1351)
- SDK https://github.com/HorizenOfficial/Sidechains-SDK/pull/902
- libevm https://github.com/HorizenOfficial/libevm/pull/17
